### PR TITLE
fix: harden resolve_user_id — cache, pagination, PII, and email fast path

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,7 +13,7 @@ RUN pip install --no-cache-dir --upgrade setuptools pip && \
 # can write cache files without a volume mount.
 ENV SLACK_MCP_DATA=/app/data
 USER 0
-RUN mkdir -p /app/data && chgrp -R 0 /app/data && chmod -R g=u /app/data
+RUN mkdir -p /app/data && chgrp -R 0 /app/data && chmod -R g=u /app/data && chmod g+s /app/data
 USER 1001
 
 CMD ["slack-mcp"]

--- a/Containerfile
+++ b/Containerfile
@@ -8,7 +8,10 @@ COPY slack_mcp_server.py ./
 RUN pip install --no-cache-dir --upgrade setuptools pip && \
     pip install --no-cache-dir .
 
-# User cache lives here; mount a volume to persist it across restarts
+# User cache lives here; mount a volume to persist it across restarts.
+# chgrp/chmod so UID 1001 (and any arbitrary UID in group 0 on OpenShift)
+# can write cache files without a volume mount.
 ENV SLACK_MCP_DATA=/app/data
+RUN mkdir -p /app/data && chgrp -R 0 /app/data && chmod -R g=u /app/data
 
 CMD ["slack-mcp"]

--- a/Containerfile
+++ b/Containerfile
@@ -12,6 +12,8 @@ RUN pip install --no-cache-dir --upgrade setuptools pip && \
 # chgrp/chmod so UID 1001 (and any arbitrary UID in group 0 on OpenShift)
 # can write cache files without a volume mount.
 ENV SLACK_MCP_DATA=/app/data
+USER 0
 RUN mkdir -p /app/data && chgrp -R 0 /app/data && chmod -R g=u /app/data
+USER 1001
 
 CMD ["slack-mcp"]

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -80,6 +80,8 @@ except OSError:
 USER_CACHE_FILE = DATA_DIR / ".user_cache.json"
 REVERSE_USER_CACHE_FILE = DATA_DIR / ".reverse_user_cache.json"
 REVERSE_CACHE_TTL_HOURS = 24
+_reverse_user_memory_cache: list[dict[str, str]] = []
+_reverse_user_memory_cache_time: datetime | None = None
 
 # Slack session tokens may also come from a dotenv-style file (default
 # <data>/tokens.env — the file scripts/slack-refresh-tokens writes) so the
@@ -187,29 +189,40 @@ async def make_request(
         log("Error: stdio mode requires SLACK_XOXC_TOKEN and SLACK_XOXD_TOKEN (or SLACK_BOT_TOKEN)")
         return None
 
+    max_retries = 5
     async with httpx.AsyncClient(cookies=cookies) as client:
-        try:
-            if method.upper() == "GET":
-                response = await client.request(
-                    method,
-                    url,
-                    headers=headers,
-                    params=payload,
-                    timeout=30.0,
-                )
-            else:
-                response = await client.request(
-                    method,
-                    url,
-                    headers=headers,
-                    json=payload,
-                    timeout=30.0,
-                )
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            log(str(e))
-            return None
+        for attempt in range(max_retries):
+            try:
+                if method.upper() == "GET":
+                    response = await client.request(
+                        method,
+                        url,
+                        headers=headers,
+                        params=payload,
+                        timeout=30.0,
+                    )
+                else:
+                    response = await client.request(
+                        method,
+                        url,
+                        headers=headers,
+                        json=payload,
+                        timeout=30.0,
+                    )
+                if response.status_code == 429 and attempt < max_retries - 1:
+                    try:
+                        delay = float(response.headers.get("Retry-After", "1"))
+                    except ValueError:
+                        delay = 1.0
+                    log(f"Rate limited (429), retrying in {delay}s (attempt {attempt + 1}/{max_retries})")
+                    await asyncio.sleep(max(delay, 1.0))
+                    continue
+                response.raise_for_status()
+                return response.json()
+            except Exception as e:
+                log(str(e))
+                return None
+    return None
 
 
 async def log_to_slack(message: str):
@@ -334,13 +347,23 @@ def _save_reverse_user_cache(users: list[dict[str, str]]) -> None:
 
 async def _fetch_all_users() -> list[dict[str, str]]:
     """Fetch all workspace users via users.list with pagination. Returns simplified user records."""
+    global _reverse_user_memory_cache, _reverse_user_memory_cache_time
+
+    if _reverse_user_memory_cache and _reverse_user_memory_cache_time:
+        age_hours = (datetime.now(timezone.utc) - _reverse_user_memory_cache_time).total_seconds() / 3600
+        if age_hours < REVERSE_CACHE_TTL_HOURS:
+            return _reverse_user_memory_cache
+
     cached = _load_reverse_user_cache()
     if cached:
+        _reverse_user_memory_cache = cached
+        _reverse_user_memory_cache_time = datetime.now(timezone.utc)
         return cached
 
     url = f"{SLACK_API_BASE}/users.list"
     all_users: list[dict[str, str]] = []
     cursor = None
+    complete = False
 
     while True:
         payload: dict[str, Any] = {"limit": 200}
@@ -367,15 +390,20 @@ async def _fetch_all_users() -> list[dict[str, str]]:
 
         cursor = data.get("response_metadata", {}).get("next_cursor")
         if not cursor:
+            complete = True
             break
 
-    if all_users:
+    if all_users and complete:
         _save_reverse_user_cache(all_users)
+        _reverse_user_memory_cache = all_users
+        _reverse_user_memory_cache_time = datetime.now(timezone.utc)
         global _user_cache
         for u in all_users:
             display = u["display_name"] or u["real_name"] or u["handle"] or u["id"]
             _user_cache[u["id"]] = display
         _save_user_cache()
+    elif all_users:
+        log(f"Partial users.list fetch ({len(all_users)} users) — not caching")
 
     log(f"Fetched {len(all_users)} users from workspace")
     return all_users
@@ -712,19 +740,22 @@ async def refresh_channel_cache() -> bool:
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, openWorldHint=True))
 async def refresh_user_cache() -> int:
     """Clear the user cache. Use this when user handles are outdated or if user lookups are failing. Returns the number of cached entries cleared."""
-    global _user_cache
+    global _user_cache, _reverse_user_memory_cache, _reverse_user_memory_cache_time
     await log_to_slack("Clearing user cache")
     count = len(_user_cache)
     _user_cache.clear()
+    _reverse_user_memory_cache = []
+    _reverse_user_memory_cache_time = None
 
-    # Also remove the cache file
-    try:
-        if USER_CACHE_FILE.exists():
-            USER_CACHE_FILE.unlink()
-            log(f"Cleared {count} user cache entries and deleted cache file")
-    except Exception as e:
-        log(f"Cleared {count} user cache entries but failed to delete cache file: {e}")
+    # Also remove the cache files
+    for cache_file in (USER_CACHE_FILE, REVERSE_USER_CACHE_FILE):
+        try:
+            if cache_file.exists():
+                cache_file.unlink()
+        except Exception as e:
+            log(f"Failed to delete {cache_file.name}: {e}")
 
+    log(f"Cleared {count} user cache entries")
     return count
 
 
@@ -734,17 +765,37 @@ async def resolve_user_id(query: str) -> list[dict[str, str]]:
     """Resolve a Slack user ID from a name, @handle, or email address.
 
     Searches the full workspace member list (cached for 24h).
+    For email queries, tries users.lookupByEmail first (single fast request)
+    before falling back to the full directory walk.
     Returns up to 5 matches sorted by relevance: exact handle > exact email >
     case-insensitive name > partial substring match.
     Each result contains id, handle, real_name, display_name, and email.
     """
-    await log_to_slack(f"Resolving user ID for: {query}")
-    users = await _fetch_all_users()
-    if not users:
-        return []
+    await log_to_slack("Resolving a user ID")
 
     q = query.strip().lstrip("@").lower()
     if not q:
+        return []
+
+    if "@" in q and "." in q:
+        data = await make_request(
+            f"{SLACK_API_BASE}/users.lookupByEmail",
+            method="GET",
+            payload={"email": q},
+        )
+        if data and data.get("ok"):
+            user = data["user"]
+            profile = user.get("profile", {})
+            return [{
+                "id": user.get("id", ""),
+                "handle": user.get("name", ""),
+                "real_name": user.get("real_name", ""),
+                "display_name": profile.get("display_name", ""),
+                "email": profile.get("email", ""),
+            }]
+
+    users = await _fetch_all_users()
+    if not users:
         return []
 
     exact_handle: list[dict[str, str]] = []

--- a/slack_mcp_server.py
+++ b/slack_mcp_server.py
@@ -303,14 +303,15 @@ def _save_user_cache() -> None:
     try:
         with open(USER_CACHE_FILE, 'w') as f:
             json.dump(_user_cache, f, indent=2)
+            os.fchmod(f.fileno(), 0o660)
     except Exception as e:
         log(f"Error saving user cache: {e}")
 
 
 
 
-def _load_reverse_user_cache() -> list[dict[str, str]]:
-    """Load the reverse user cache from disk. Returns empty list if stale or missing."""
+def _load_reverse_user_cache() -> tuple[list[dict[str, str]], datetime | None]:
+    """Load the reverse user cache from disk. Returns (users, fetched_at) or ([], None) if stale or missing."""
     try:
         if REVERSE_USER_CACHE_FILE.exists():
             with open(REVERSE_USER_CACHE_FILE, 'r') as f:
@@ -320,11 +321,11 @@ def _load_reverse_user_cache() -> list[dict[str, str]]:
             if age_hours < REVERSE_CACHE_TTL_HOURS:
                 users = data.get("users", [])
                 log(f"Loaded reverse user cache ({len(users)} users, {age_hours:.1f}h old)")
-                return users
+                return users, fetched_at
             log(f"Reverse user cache expired ({age_hours:.1f}h old)")
     except Exception as e:
         log(f"Error loading reverse user cache: {e}")
-    return []
+    return [], None
 
 
 def _save_reverse_user_cache(users: list[dict[str, str]]) -> None:
@@ -340,6 +341,7 @@ def _save_reverse_user_cache(users: list[dict[str, str]]) -> None:
         }
         with open(REVERSE_USER_CACHE_FILE, 'w') as f:
             json.dump(data, f, indent=2)
+            os.fchmod(f.fileno(), 0o660)
         log(f"Saved reverse user cache ({len(sanitized)} users)")
     except Exception as e:
         log(f"Error saving reverse user cache: {e}")
@@ -354,10 +356,10 @@ async def _fetch_all_users() -> list[dict[str, str]]:
         if age_hours < REVERSE_CACHE_TTL_HOURS:
             return _reverse_user_memory_cache
 
-    cached = _load_reverse_user_cache()
+    cached, fetched_at = _load_reverse_user_cache()
     if cached:
         _reverse_user_memory_cache = cached
-        _reverse_user_memory_cache_time = datetime.now(timezone.utc)
+        _reverse_user_memory_cache_time = fetched_at
         return cached
 
     url = f"{SLACK_API_BASE}/users.list"


### PR DESCRIPTION
## Summary

Fixes four open bugs in `resolve_user_id` and its supporting cache/pagination code, all stemming from the original implementation in #54:

- **Containerfile: writable data dir** (#66) — `SLACK_MCP_DATA=/app/data` was never created; UID 1001 could not write cache files, so the "cached for 24h" behaviour never happened in container mode. Creates the directory with OpenShift-safe group permissions (`chgrp 0 / chmod g=u / setgid`), and cache files are written with `0o660` so later arbitrary UIDs in group 0 can update them.
- **`make_request`: retry on HTTP 429** (#66) — `users.list` (Tier 2, ~20 req/min) hits rate limits on large workspaces. Now retries up to 5 times, honouring the `Retry-After` header. All other HTTP errors behave as before.
- **`_fetch_all_users`: don't cache partial results** (#56) — A mid-pagination failure used to persist the truncated user list for 24h. Now tracks a `complete` flag; partial fetches are returned for the current call but never written to disk.
- **In-memory cache layer** (#55) — Disk cache correctly strips email (PII), but that broke email lookups after restart. Adds a process-lifetime memory cache that retains email fields. Disk remains the cold-start fallback for name/handle lookups. Memory cache preserves the original `fetched_at` timestamp from disk to avoid extending TTL beyond 24h.
- **`resolve_user_id`: email fast path via `users.lookupByEmail`** (#66) — Email-shaped queries now try `users.lookupByEmail` (Tier 3, single request) before the full directory walk. Avoids the multi-minute cold walk on large workspaces that caused MCP client timeouts. Note: requires bot token (`xoxb`); gracefully falls back for session tokens (`xoxc`).
- **`resolve_user_id`: stop logging PII** (#57) — `log_to_slack(f"Resolving user ID for: {query}")` leaked email addresses into the Slack logs channel. Changed to `log_to_slack("Resolving a user ID")`.
- **`refresh_user_cache`: clear all caches** — Now also clears the reverse user cache (both memory and disk), not just the ID→handle map.

**⚠️ Note on fix ordering (#66):** Fixing the Containerfile alone (writable data dir) without fixing partial-cache persistence makes things *worse* — it would enable persisting a truncated user list for 24h. Both fixes land together in this PR.

Closes #55, closes #56, closes #57, closes #66

## Acknowledgements

This PR is based on the thorough root-cause analysis, proposed fixes, and local verification by @thomaswilson27527 in #66. Their investigation on a Red Hat Enterprise Grid workspace (28,430 users) identified all three compounding defects and confirmed the fixes.

## Test plan

Tested on a Red Hat Enterprise Grid workspace (28,497 users):

- [x] Container build succeeds and cache files are writable without a volume mount (`/app/data` setgid 2775, files created as 660 group root)
- [x] `resolve_user_id` with an email address attempts `lookupByEmail` first (confirmed via stderr; falls back to full walk for `xoxc` tokens as expected)
- [x] `resolve_user_id` with a name/handle uses cached results on second call (instant response from memory cache)
- [x] 429 rate limits are retried with Retry-After backoff (9 retries observed across full walk, all successful)
- [x] Full pagination completes and cache is persisted (28,497 users, 3.9MB `.reverse_user_cache.json`)
- [x] `refresh_user_cache` clears both `.user_cache.json` and `.reverse_user_cache.json`
- [x] No PII (email) appears in the configured Slack logs channel (all calls logged as "Resolving a user ID")
- [x] Disk cache does not contain email field (verified: keys are `id, handle, real_name, display_name` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)